### PR TITLE
Dockerfile: fix volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ ENV LOUNGE_SRC "${LOUNGE_HOME}/src"
 RUN groupadd --gid ${gid} ${group} \
       && useradd --home "${LOUNGE_HOME}" --create-home --uid ${uid} --gid ${gid} ${user}
 
+RUN mkdir -p "${LOUNGE_DATA}"
+RUN chown -R ${user}:${group} "${LOUNGE_DATA}"
 VOLUME "${LOUNGE_DATA}"
-RUN chown -R ${user} "${LOUNGE_DATA}"
 
 # Drop root.
 USER ${user}


### PR DESCRIPTION
Directives weren't executed in the right order, effectively messing up ownership of lounge's home dir causing crashes in containers without a properly mounted volume.