### PR TITLE
Add Dockerfile for Alpine Linux that runs Node 6

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,18 @@
+FROM mhart/alpine-node:6
+
+ENV GIT_REV="master"
+
+RUN apk add --no-cache openssh git
+
+RUN git clone https://github.com/thelounge/lounge.git lounge-repo && \
+  cd lounge-repo && \
+  git reset --hard $GIT_REV && \
+  npm install -g && \
+  npm install && \
+  npm run build && \
+  rm -rf /usr/lib/node_modules/thelounge/client && \
+  mv client/ /usr/lib/node_modules/thelounge/client && \
+  cd && rm -rf lounge-repo
+
+EXPOSE 9000
+CMD lounge

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM mhart/alpine-node:6
 
-ENV GIT_REV="master"
+ARG GIT_REV="master"
 
 RUN apk add --no-cache openssh git
 


### PR DESCRIPTION
More info about the image can be found on [my repo](https://github.com/daGrevis/docker-thelounge).

Some notes:

* It's based on Alpine Linux (image size is 186 MB instead of 679 MB),
* It runs Node 6 instead Node 4,
* It builds from Git revision every time.

Impaloo from #thelounge suggested me to create a pull request.