### PR TITLE
Don't drop from root, causes error when changing file permission

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,9 @@ FROM node:6
 ENV LOUNGE_VERSION 2.0.1
 ENV NODE_ENV production
 
-ARG user=lounge
-ARG group=lounge
-ARG uid=1000
-ARG gid=1000
-
 ENV LOUNGE_HOME "/home/lounge/data"
 
-# Create a non-root user for lounge to run in.
-RUN groupadd --gid ${gid} ${group} \
-      && useradd --create-home --uid ${uid} --gid ${gid} ${user}
-
 RUN mkdir -p "${LOUNGE_HOME}"
-RUN chown -R ${user}:${group} "${LOUNGE_HOME}"
 VOLUME "${LOUNGE_HOME}"
 
 # Install thelounge.

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,4 @@ EXPOSE ${PORT}
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-# Drop root.
-USER ${user}
-
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -31,8 +31,3 @@ You can control how The Lounge is started through the following environment vari
 ## Where is data stored?
 
 Lounge reads and stores its configuration, logs and other data at `/home/lounge/data`.
-
-## What user does lounge run as?
-
-Lounge runs as the `lounge:lounge` user by default, with `uid=1000, gid=1000`. These can be
-overridden with the `user`, `uid`, `group`, `gid` [build args](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables-build-arg).


### PR DESCRIPTION
When running docker-compose with volumes, I always get this error from lounge. 

```javascript
Error: EPERM: operation not permitted, chmod '/home/lounge/data'
    at Error (native)
    at Object.fs.chmodSync (fs.js:997:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/thelounge/src/command-line/index.js:20:5)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/thelounge/index.js:13:1)
fs.js:997
  return binding.chmod(pathModule._makeLong(path), modeNum(mode));
```

Which basically means it cannot change the permission of the folder `data` because it doesn't have the right permission.

It's either we don't drop the user to lounge or we don't do a `chmod` on https://github.com/thelounge/lounge/blob/master/src/command-line/index.js#L20