### PR TITLE
Accept LOUNGE_VERSION as `docker build` arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:6
 
-ENV LOUNGE_VERSION 2.4.0
+ARG THELOUNGE_VERSION=2.4.0
 ENV NODE_ENV production
 
 ENV LOUNGE_HOME "/home/lounge/data"
@@ -15,7 +15,7 @@ RUN mkdir -p "${LOUNGE_HOME}"
 VOLUME "${LOUNGE_HOME}"
 
 # Install thelounge.
-RUN npm install -g thelounge@${LOUNGE_VERSION} && \
+RUN npm install -g thelounge@${THELOUNGE_VERSION} && \
     npm cache clean
 
 # Expose HTTP.

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:6-alpine
 
-ENV LOUNGE_VERSION 2.4.0
+ARG THELOUNGE_VERSION=2.4.0
 ENV NODE_ENV production
 
 ENV LOUNGE_HOME "/home/lounge/data"
@@ -9,7 +9,7 @@ RUN mkdir -p "${LOUNGE_HOME}"
 VOLUME "${LOUNGE_HOME}"
 
 # Install thelounge.
-RUN npm install -g thelounge@${LOUNGE_VERSION} && \
+RUN npm install -g thelounge@${THELOUNGE_VERSION} && \
     npm cache clean
 
 # Expose HTTP.

--- a/slim/Dockerfile
+++ b/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:6-slim
 
-ENV LOUNGE_VERSION 2.4.0
+ARG THELOUNGE_VERSION=2.4.0
 ENV NODE_ENV production
 
 ENV LOUNGE_HOME "/home/lounge/data"
@@ -9,7 +9,7 @@ RUN mkdir -p "${LOUNGE_HOME}"
 VOLUME "${LOUNGE_HOME}"
 
 # Install thelounge.
-RUN npm install -g thelounge@${LOUNGE_VERSION} && \
+RUN npm install -g thelounge@${THELOUNGE_VERSION} && \
     npm cache clean
 
 # Expose HTTP.


### PR DESCRIPTION
Allows configuration of ~~`THELOUNGE_VERSION`~~ `LOUNGE_VERSION` via a build argument.

This allows me to run:

```
docker build -t rjacksonm1/lounge:v2.5.0-rc.1 --build-arg THELOUNGE_VERSION=2.5.0-rc.1 .

docker build -f alpine/Dockerfile -t rjacksonm1/lounge:v2.5.0-rc.1-alpine --build-arg THELOUNGE_VERSION=2.5.0-rc.1 .

docker build -f slim/Dockerfile -t rjacksonm1/lounge:v2.5.0-rc.1-slim --build-arg THELOUNGE_VERSION=2.5.0-rc.1 .
```

to build [images of the latest pre-release](https://hub.docker.com/r/rjacksonm1/lounge/tags/) 😉