### PR TITLE
Add makefile to build all images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+THELOUNGE_VERSION?=2.4.0
+ORGANISATION?=thelounge
+
+all: main alpine slim
+
+main:
+	docker build -t ${ORGANISATION}/lounge:v${THELOUNGE_VERSION} --build-arg THELOUNGE_VERSION=${THELOUNGE_VERSION} .
+
+
+alpine:
+	docker build -f alpine/Dockerfile -t ${ORGANISATION}/lounge:v${THELOUNGE_VERSION}-alpine --build-arg THELOUNGE_VERSION=${THELOUNGE_VERSION} .
+
+
+slim:
+	docker build -f slim/Dockerfile -t ${ORGANISATION}/lounge:v${THELOUNGE_VERSION}-slim --build-arg THELOUNGE_VERSION=${THELOUNGE_VERSION} .
+
+.PHONY: alpine slim


### PR DESCRIPTION
Makefile to build images, with options to override organisation or version:

To build the release hardcoded in this repo (v2.4.0), tagged as `thelounge/lounge:v2.4.0[-slim|-alpine]:

```
➜  docker-lounge git:(makefile) ✗ make
...
➜  docker-lounge git:(makefile) ✗ docker images | grep thelounge
thelounge/lounge                       v2.4.0-slim          1b15577445f8        29 seconds ago       242MB
thelounge/lounge                       v2.4.0-alpine        afd450110ea5        55 seconds ago       79.6MB
thelounge/lounge                       v2.4.0               e8b0794da80f        About a minute ago   718MB
```

To build v2.5.0-rc.2:

```
➜  docker-lounge git:(makefile) ✗ THELOUNGE_VERSION=2.5.0-rc.2 make
...
➜  docker-lounge git:(makefile) ✗ docker images | grep thelounge
thelounge/lounge                       v2.5.0-rc.2-alpine   bd4b85402d38        6 hours ago         80MB
thelounge/lounge                       v2.5.0-rc.2-slim     7388a4e06ead        6 hours ago         242MB
thelounge/lounge                       v2.5.0-rc.2          f4ee3aeaa52e        6 hours ago         718MB

```

And to tag it to my own org:

```
➜  docker-lounge git:(makefile) ✗ ORGANISATION=rjacksonm1 THELOUNGE_VERSION=2.5.0-rc.2 make
...
➜  docker-lounge git:(makefile) ✗ docker images | grep rjacksonm1/lounge
rjacksonm1/lounge                      v2.5.0-rc.2-alpine   bd4b85402d38        6 hours ago         80MB
rjacksonm1/lounge                      v2.5.0-rc.2-slim     7388a4e06ead        6 hours ago         242MB
rjacksonm1/lounge                      v2.5.0-rc.2          f4ee3aeaa52e        6 hours ago         718MB
```