### PR TITLE
tweak Dockerfiles, mostly for better caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
 FROM node:6
 
-ARG THELOUNGE_VERSION=2.7.0
 ENV NODE_ENV production
 
 ENV THELOUNGE_HOME "/home/lounge/data"
+VOLUME "${THELOUNGE_HOME}"
+
+# Expose HTTP.
+ENV PORT 9000
+EXPOSE ${PORT}
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["thelounge", "start"]
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # Install common TTY text editors to allow editing files from within the container
 RUN apt-get update && \
@@ -11,19 +20,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p "${THELOUNGE_HOME}"
-VOLUME "${THELOUNGE_HOME}"
-
 # Install thelounge.
+ARG THELOUNGE_VERSION=2.7.0
 RUN npm install -g thelounge@${THELOUNGE_VERSION} && \
     npm cache clean
-
-# Expose HTTP.
-ENV PORT 9000
-EXPOSE ${PORT}
-
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-
-CMD ["thelounge", "start"]
-
-ENTRYPOINT ["docker-entrypoint.sh"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,23 +1,20 @@
 FROM node:6-alpine
 
-ARG THELOUNGE_VERSION=2.7.0
 ENV NODE_ENV production
 
 ENV THELOUNGE_HOME "/home/lounge/data"
-
-RUN mkdir -p "${THELOUNGE_HOME}"
 VOLUME "${THELOUNGE_HOME}"
-
-# Install thelounge.
-RUN npm install -g thelounge@${THELOUNGE_VERSION} && \
-    npm cache clean
 
 # Expose HTTP.
 ENV PORT 9000
 EXPOSE ${PORT}
 
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["thelounge", "start"]
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+# Install thelounge.
+ARG THELOUNGE_VERSION=2.7.0
+RUN npm install -g thelounge@${THELOUNGE_VERSION} && \
+    npm cache clean

--- a/slim/Dockerfile
+++ b/slim/Dockerfile
@@ -1,23 +1,20 @@
 FROM node:6-slim
 
-ARG THELOUNGE_VERSION=2.7.0
 ENV NODE_ENV production
 
 ENV THELOUNGE_HOME "/home/lounge/data"
-
-RUN mkdir -p "${THELOUNGE_HOME}"
 VOLUME "${THELOUNGE_HOME}"
-
-# Install thelounge.
-RUN npm install -g thelounge@${THELOUNGE_VERSION} && \
-    npm cache clean
 
 # Expose HTTP.
 ENV PORT 9000
 EXPOSE ${PORT}
 
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["thelounge", "start"]
 
-ENTRYPOINT ["docker-entrypoint.sh"]
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+# Install thelounge.
+ARG THELOUNGE_VERSION=2.7.0
+RUN npm install -g thelounge@${THELOUNGE_VERSION} && \
+    npm cache clean


### PR DESCRIPTION
These minor edits to the Dockerfiles tidy up the files and make better
use of docker layers for caching. The best change is moving the
`ARG THELOUNGE_VERSION` along with the npm install to then end of the
Dockerfile. Bumping the version needlessy busts the cache for everything
that comes after. It is safe to move the install to the very end since
everything else is either docker metadata or runtime configuration that
does not affect installation.

The VOLUME command will create the directory if it doesn't exist,
so we can remove the mkdir.

At runtime, the ENTRYPOINT is always run before CMD or container args,
having the Dockerfile reflect that just seems nice.

I moved the COPY docker-entrypoint.sh before lounge gets installed
because it changes less often than lounge version bumps so we get to
make use of the cache more often.

I moved the version ARG until the very end so that we don't bust the
cache unnecessarily for stages that are not affected by the version.

I also rearranged the EXPOSE and install stages because install does not
depend on it and it lets us make better use of the cache.