### PR TITLE
Python no longer bundles setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ CMD ["thelounge", "start"]
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # Install thelounge.
-RUN apk --update --no-cache --virtual build-deps add python3 build-base git && \
-    ln -sf python3 /usr/bin/python && \
+RUN apk --update --no-cache --virtual build-deps add python3 build-base git py-setuptools && \
     yarn --non-interactive --frozen-lockfile global add thelounge@${THELOUNGE_VERSION} && \
     yarn --non-interactive cache clean && \
     apk del --purge build-deps && \


### PR DESCRIPTION
Addresses #195
I'd still prefer if the `yarn global add` command line were changed in a way that returned a non-zero exit status if anything failed to install, but this at least allows everything to work correctly on platforms that need node-gyp.