### PR TITLE
fix: service "thelounge" refers to undefined volume thelounge

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,7 @@ services:
       - "9000:9000"
     restart: always
     volumes:
-      - thelounge:/var/opt/thelounge # uses a named volume on the host
+      - thelounge:/var/opt/thelounge # uses a named volume
+
+volumes:
+  thelounge:


### PR DESCRIPTION
Previously, a named volume was referenced but not defined in the compose file, which caused deployment issues: `service "thelounge" refers to undefined volume thelounge: invalid compose project`. This PR explicitly defines the required volume in the compose file.

Alternatively, the volume could be created manually with the command `docker volume create thelounge`, but one would still need to define it in compose file.