### PR TITLE
Bump The Lounge to 4.5.2-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.5.2-rc.1 (2026-07-06)
+- Bump [`thelounge`][1] to [`4.5.2-rc.1`](https://github.com/thelounge/thelounge/releases/tag/v4.5.2-rc.1).
+
 ## [4.5.0](https://github.com/thelounge/thelounge-docker/compare/4.5.0-rc.2...4.5.0) (2026-05-20)
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-alpine
 
-ARG THELOUNGE_VERSION=4.5.0
+ARG THELOUNGE_VERSION=4.5.2-rc.1
 
 LABEL org.opencontainers.image.title "Official The Lounge image"
 LABEL org.opencontainers.image.description "Official Docker image for The Lounge, a modern web IRC client designed for self-hosting."

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-command -v gsed &> /dev/null || {
-    >&2 echo "gsed command missing"
+command -v sed &> /dev/null || {
+    >&2 echo "sed command missing"
     exit 1
 }
 
@@ -15,9 +15,11 @@ fi
 replace_regex_in_file() {
     local REGEX="$1"
     shift 1
-    local FILES=$@
-    for file in $FILES; do
-        gsed -i -E "s/${REGEX}/\1${NEW_VERSION}/" "$file"
+    local FILES=("$@")
+    for file in "${FILES[@]}"; do
+        [[ -f "$file" ]] || continue
+        sed -i.bak -E "s/${REGEX}/\1${NEW_VERSION}/" "$file"
+        rm -f "${file}.bak"
     done
 }
 


### PR DESCRIPTION
## Summary
- bump Dockerfile THELOUNGE_VERSION to 4.5.2-rc.1
- add the 4.5.2-rc.1 changelog entry
- make scripts/update-version.sh portable on macOS/default sed and tolerant of the removed Makefile

## Validation
- npm view thelounge@4.5.2-rc.1
- gh release view v4.5.2-rc.1 --repo thelounge/thelounge
- bash -n scripts/update-version.sh
- git diff --check
- ./scripts/update-version.sh 4.5.2-rc.1
- docker build --platform linux/arm64/v8 --load -t thelounge-docker:4.5.2-rc.1-test -f Dockerfile .
- docker run smoke test: thelounge --version, HTML title, no [ERROR] logs, config.js creation
- docker buildx build --platform linux/amd64,linux/arm64/v8,linux/arm/v7 --file Dockerfile .
