### PR TITLE
Bump The Lounge to 4.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## 4.5.2-rc.1 (2026-07-06)
-- Bump [`thelounge`][1] to [`4.5.2-rc.1`](https://github.com/thelounge/thelounge/releases/tag/v4.5.2-rc.1).
+## 4.5.2 (2026-07-11)
+- Bump [`thelounge`][1] to [`4.5.2`](https://github.com/thelounge/thelounge/releases/tag/v4.5.2).
 
 ## [4.5.0](https://github.com/thelounge/thelounge-docker/compare/4.5.0-rc.2...4.5.0) (2026-05-20)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-alpine
 
-ARG THELOUNGE_VERSION=4.5.2-rc.1
+ARG THELOUNGE_VERSION=4.5.2
 
 LABEL org.opencontainers.image.title "Official The Lounge image"
 LABEL org.opencontainers.image.description "Official Docker image for The Lounge, a modern web IRC client designed for self-hosting."


### PR DESCRIPTION
Bumps `thelounge` to [4.5.2](https://github.com/thelounge/thelounge/releases/tag/v4.5.2) via `./scripts/update-version.sh`. Removes the superseded 4.5.2-rc.1 changelog entry.