### PR TITLE
Bump The Lounge to 4.6.0-pre.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.6.0-pre.1 (2026-07-22)
+- Bump [`thelounge`][1] to [`4.6.0-pre.1`](https://github.com/thelounge/thelounge/releases/tag/v4.6.0-pre.1).
+
 ## 4.5.2 (2026-07-11)
 - Bump [`thelounge`][1] to [`4.5.2`](https://github.com/thelounge/thelounge/releases/tag/v4.5.2).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-alpine
 
-ARG THELOUNGE_VERSION=4.5.2
+ARG THELOUNGE_VERSION=4.6.0-pre.1
 
 LABEL org.opencontainers.image.title "Official The Lounge image"
 LABEL org.opencontainers.image.description "Official Docker image for The Lounge, a modern web IRC client designed for self-hosting."


### PR DESCRIPTION
Bumps to [v4.6.0-pre.1](https://github.com/thelounge/thelounge/releases/tag/v4.6.0-pre.1). After merge, tag `4.6.0-pre.1` to trigger the image build.